### PR TITLE
feat: dark design token foundation (issue #17)

### DIFF
--- a/scripts/test-design-tokens.mjs
+++ b/scripts/test-design-tokens.mjs
@@ -1,0 +1,131 @@
+// Design token acceptance tests for issue #17 — Dark Design Token Foundation
+import { readFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import assert from 'assert';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const css = readFileSync(join(__dirname, '../src/app/globals.css'), 'utf-8');
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    passed++;
+  } catch (e) {
+    console.log(`  ✗ ${name}`);
+    console.log(`    ${e.message}`);
+    failed++;
+  }
+}
+
+function getRootToken(name) {
+  const rootMatch = css.match(/:root\s*\{([^}]+)\}/s);
+  if (!rootMatch) throw new Error(':root block not found');
+  const tokenMatch = rootMatch[1].match(new RegExp(`${name.replace('--', '--')}:\\s*([^;]+);`));
+  if (!tokenMatch) throw new Error(`Token ${name} not found in :root`);
+  return tokenMatch[1].trim();
+}
+
+function getThemeInlineBlock() {
+  const match = css.match(/@theme\s+inline\s*\{([^}]+)\}/s);
+  if (!match) throw new Error('@theme inline block not found');
+  return match[1];
+}
+
+function getOklchLightness(value) {
+  const match = value.match(/oklch\(\s*([\d.]+)/);
+  if (!match) throw new Error(`Not an oklch value: "${value}"`);
+  return parseFloat(match[1]);
+}
+
+function getOklchHue(value) {
+  const match = value.match(/oklch\(\s*[\d.]+\s+[\d.]+\s+([\d.]+)/);
+  if (!match) throw new Error(`Cannot extract hue from oklch value: "${value}"`);
+  return parseFloat(match[1]);
+}
+
+console.log('\nDesign Token Tests\n');
+
+// Tracer bullet: background must be dark
+test('--background in :root is dark (lightness < 0.20)', () => {
+  const value = getRootToken('--background');
+  const l = getOklchLightness(value);
+  assert(l < 0.20, `Expected lightness < 0.20, got ${l} (value: ${value})`);
+});
+
+test('--background in :root uses a warm hue (20 ≤ H ≤ 100)', () => {
+  const value = getRootToken('--background');
+  const h = getOklchHue(value);
+  assert(h >= 20 && h <= 100, `Expected hue 20–100, got ${h} (value: ${value})`);
+});
+
+test('--foreground in :root is near-white (lightness > 0.90)', () => {
+  const value = getRootToken('--foreground');
+  const l = getOklchLightness(value);
+  assert(l > 0.90, `Expected lightness > 0.90, got ${l} (value: ${value})`);
+});
+
+test('--card in :root is elevated above background (L > bg L, but still dark L < 0.30)', () => {
+  const bgValue = getRootToken('--background');
+  const cardValue = getRootToken('--card');
+  const bgL = getOklchLightness(bgValue);
+  const cardL = getOklchLightness(cardValue);
+  assert(cardL > bgL, `Expected card L (${cardL}) > background L (${bgL})`);
+  assert(cardL < 0.30, `Expected card L < 0.30, got ${cardL}`);
+});
+
+test('--muted in :root is dark (lightness < 0.30)', () => {
+  const value = getRootToken('--muted');
+  const l = getOklchLightness(value);
+  assert(l < 0.30, `Expected lightness < 0.30, got ${l} (value: ${value})`);
+});
+
+test('--border in :root is a subtle value (not the original light oklch(0.92 ...))', () => {
+  const value = getRootToken('--border');
+  assert(
+    !value.includes('oklch(0.92'),
+    `Border should not be the original light value, got: ${value}`
+  );
+});
+
+test('--primary amber token is unchanged (oklch(0.705 0.213 47.604))', () => {
+  const value = getRootToken('--primary');
+  assert(
+    value === 'oklch(0.705 0.213 47.604)',
+    `Expected amber primary unchanged, got: ${value}`
+  );
+});
+
+test('@keyframes fadeInUp is defined in globals.css', () => {
+  assert(
+    css.includes('@keyframes fadeInUp'),
+    '@keyframes fadeInUp not found in globals.css'
+  );
+});
+
+test('@keyframes fadeInUp has from/to with opacity and transform', () => {
+  const kfMatch = css.match(/@keyframes\s+fadeInUp\s*\{([^}]+(?:\{[^}]*\}[^}]*)*)\}/s);
+  assert(kfMatch, '@keyframes fadeInUp block not parseable');
+  const kfBody = kfMatch[1];
+  assert(kfBody.includes('opacity'), 'fadeInUp should include opacity');
+  assert(kfBody.includes('transform'), 'fadeInUp should include transform');
+});
+
+test('--font-playfair is defined in @theme inline block', () => {
+  const themeBlock = getThemeInlineBlock();
+  assert(
+    themeBlock.includes('--font-playfair'),
+    '--font-playfair not found in @theme inline block'
+  );
+});
+
+test('.dark class is still present (untouched)', () => {
+  assert(css.includes('.dark {') || css.includes('.dark{'), '.dark class not found in globals.css');
+});
+
+console.log(`\n${passed + failed} tests: ${passed} passed, ${failed} failed\n`);
+if (failed > 0) process.exit(1);

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -8,6 +8,7 @@
   --color-foreground: var(--foreground);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
+  --font-playfair: var(--font-playfair-display);
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
@@ -46,36 +47,36 @@
 
 :root {
   --radius: 0.5rem;
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.141 0.005 285.823);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.141 0.005 285.823);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.141 0.005 285.823);
+  --background: oklch(0.12 0.008 60);
+  --foreground: oklch(0.94 0.008 80);
+  --card: oklch(0.17 0.008 55);
+  --card-foreground: oklch(0.94 0.008 80);
+  --popover: oklch(0.17 0.008 55);
+  --popover-foreground: oklch(0.94 0.008 80);
   --primary: oklch(0.705 0.213 47.604);
   --primary-foreground: oklch(0.98 0.016 73.684);
-  --secondary: oklch(0.967 0.001 286.375);
-  --secondary-foreground: oklch(0.21 0.006 285.885);
-  --muted: oklch(0.967 0.001 286.375);
-  --muted-foreground: oklch(0.552 0.016 285.938);
-  --accent: oklch(0.967 0.001 286.375);
-  --accent-foreground: oklch(0.21 0.006 285.885);
+  --secondary: oklch(0.22 0.006 55);
+  --secondary-foreground: oklch(0.94 0.008 80);
+  --muted: oklch(0.22 0.006 55);
+  --muted-foreground: oklch(0.60 0.010 65);
+  --accent: oklch(0.22 0.006 55);
+  --accent-foreground: oklch(0.94 0.008 80);
   --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.92 0.004 286.32);
-  --input: oklch(0.92 0.004 286.32);
+  --border: oklch(1 0 0 / 12%);
+  --input: oklch(1 0 0 / 15%);
   --ring: oklch(0.705 0.213 47.604);
   --chart-1: oklch(0.646 0.222 41.116);
   --chart-2: oklch(0.6 0.118 184.704);
   --chart-3: oklch(0.398 0.07 227.392);
   --chart-4: oklch(0.828 0.189 84.429);
   --chart-5: oklch(0.769 0.188 70.08);
-  --sidebar: oklch(0.985 0 0);
-  --sidebar-foreground: oklch(0.141 0.005 285.823);
+  --sidebar: oklch(0.15 0.008 58);
+  --sidebar-foreground: oklch(0.94 0.008 80);
   --sidebar-primary: oklch(0.705 0.213 47.604);
   --sidebar-primary-foreground: oklch(0.98 0.016 73.684);
-  --sidebar-accent: oklch(0.967 0.001 286.375);
-  --sidebar-accent-foreground: oklch(0.21 0.006 285.885);
-  --sidebar-border: oklch(0.92 0.004 286.32);
+  --sidebar-accent: oklch(0.22 0.006 55);
+  --sidebar-accent-foreground: oklch(0.94 0.008 80);
+  --sidebar-border: oklch(1 0 0 / 12%);
   --sidebar-ring: oklch(0.705 0.213 47.604);
 }
 
@@ -111,6 +112,17 @@
   --sidebar-accent-foreground: oklch(0.985 0 0);
   --sidebar-border: oklch(1 0 0 / 10%);
   --sidebar-ring: oklch(0.646 0.222 41.116);
+}
+
+@keyframes fadeInUp {
+  from {
+    opacity: 0;
+    transform: translateY(1.5rem);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 @layer base {


### PR DESCRIPTION
Shifts `:root` design tokens to a warm neutral dark OKLCH palette, making the site dark-by-default. Adds `@keyframes fadeInUp` and `--font-playfair` for downstream components.

Closes #17

Generated with [Claude Code](https://claude.ai/code)