### PR TITLE
feat: Skills & About sections redesign (issue #19)

### DIFF
--- a/src/components/sections/about.tsx
+++ b/src/components/sections/about.tsx
@@ -1,12 +1,11 @@
 import { cn } from "@/lib/utils";
 import SectionWrapper from "./wrapper";
 import { SectionMainButton } from "./main-button";
+import { UserRound } from "lucide-react";
 
 export default function AboutSection() {
   return (
     <SectionWrapper id="about" title="About Me">
-      {/* Header - Responsive */}
-
       {/* Content Container */}
       <div
         className={cn(
@@ -18,16 +17,25 @@ export default function AboutSection() {
           "gap-20 md:gap-12 lg:gap-36"
         )}
       >
-        {/* Image Container */}
+        {/* Image placeholder — swap inner content for Next.js <Image> when ready */}
         <div
           className={cn(
-            "w-full relative overflow-hidden",
+            "w-full relative",
             "h-48 md:h-72 lg:h-[402px]",
-            "max-w-[350px] md:max-w-[450px] lg:max-w-[550px]"
+            "max-w-[350px] md:max-w-[450px] lg:max-w-[550px]",
+            "bg-card",
+            "border-2 border-dashed border-primary",
+            "flex flex-col items-center justify-center gap-3"
           )}
         >
-          <div className="absolute md:mt-5 lg:mt-0 inset-0 bg-zinc-200" />
-          <div className="absolute w-16 h-16 left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2" />
+          <UserRound
+            className="text-primary"
+            size={64}
+            strokeWidth={1}
+          />
+          <span className="text-muted-foreground text-sm font-['Mulish'] uppercase tracking-widest">
+            Photo Placeholder
+          </span>
         </div>
 
         {/* Text Content */}
@@ -35,8 +43,9 @@ export default function AboutSection() {
           className={cn(
             "w-full lg:flex-1",
             "max-w-[600px]",
-            " text-xl md:text-2xl font-normal font-['Inter'] leading-7",
-            "text-foreground text-center lg:text-left"
+            "text-xl md:text-2xl font-normal font-['Inter'] leading-7",
+            "text-foreground text-center lg:text-left",
+            "lg:border-l-4 lg:border-primary lg:pl-6"
           )}
         >
           With 20+ years of experience in solutioning problems with coding and

--- a/src/components/sections/skills.tsx
+++ b/src/components/sections/skills.tsx
@@ -1,42 +1,66 @@
 import { cn } from "@/lib/utils";
 import SectionWrapper from "./wrapper";
 import { SectionMainButton } from "./main-button";
+import {
+  SiReact,
+  SiNextdotjs,
+  SiTypescript,
+  SiNodedotjs,
+  SiPython,
+  SiAmazonwebservices,
+} from "@icons-pack/react-simple-icons";
+
+type IconComponent = React.ComponentType<{
+  size?: number;
+  color?: string;
+  className?: string;
+}>;
 
 type SkillProps = {
   name: string;
   level: string;
   progress: number;
-  icon?: React.ReactNode;
+  Icon: IconComponent;
 };
 
 const skills: SkillProps[] = [
-  { name: "React", level: "Advanced", progress: 90 },
-  { name: "Next.js", level: "Advanced", progress: 85 },
-  { name: "TypeScript", level: "Advanced", progress: 85 },
-  { name: "Node.js", level: "Intermediate", progress: 75 },
-  { name: "Python", level: "Intermediate", progress: 70 },
-  { name: "AWS", level: "Intermediate", progress: 65 },
+  { name: "React", level: "Advanced", progress: 90, Icon: SiReact },
+  { name: "Next.js", level: "Advanced", progress: 85, Icon: SiNextdotjs },
+  { name: "TypeScript", level: "Advanced", progress: 85, Icon: SiTypescript },
+  { name: "Node.js", level: "Intermediate", progress: 75, Icon: SiNodedotjs },
+  { name: "Python", level: "Intermediate", progress: 70, Icon: SiPython },
+  { name: "AWS", level: "Intermediate", progress: 65, Icon: SiAmazonwebservices },
 ];
 
-function SkillCard({ name, level, progress, icon }: SkillProps) {
+function SkillCard({
+  name,
+  level,
+  progress,
+  Icon,
+  index,
+}: SkillProps & { index: number }) {
   return (
-    <div className="w-36 h-48 p-4 bg-card flex flex-col justify-start items-center gap-3">
-      <div className="w-full h-20 max-w-32 relative overflow-hidden">
-        {icon ? (
-          icon
-        ) : (
-          <div className="w-24 h-14 absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 outline-4 outline-offset-[-2px] outline-border" />
-        )}
+    <div
+      className={cn(
+        "w-36 h-48 p-4 bg-card",
+        "flex flex-col justify-start items-center gap-3",
+        "border-t-2 border-primary",
+        "animate-fade-in opacity-0"
+      )}
+      style={{ animationDelay: `${index * 100}ms`, animationFillMode: "forwards" }}
+    >
+      <div className="w-full h-20 max-w-32 flex items-center justify-center">
+        <Icon size={48} className="text-primary" color="currentColor" />
       </div>
-      <div className="w-56 text-center text-foreground text-base font-extrabold font-['Mulish'] uppercase tracking-wider">
+      <div className="w-full text-center text-foreground text-base font-extrabold font-['Mulish'] uppercase tracking-wider">
         {name}
       </div>
       <div className="self-stretch text-center text-foreground/80 text-xs font-light font-['Mulish'] uppercase tracking-wide">
         {level}
       </div>
-      <div className="self-stretch h-5 relative bg-muted">
+      <div className="self-stretch h-1.5 relative bg-muted rounded-full overflow-hidden">
         <div
-          className="h-5 absolute left-0 top-0 bg-primary/30"
+          className="h-1.5 absolute left-0 top-0 bg-primary rounded-full"
           style={{ width: `${progress}%` }}
         />
       </div>
@@ -47,9 +71,6 @@ function SkillCard({ name, level, progress, icon }: SkillProps) {
 export default function SkillsSection() {
   return (
     <SectionWrapper id="skills" title="My Skills">
-      {/* Header - Responsive */}
-
-      {/* Skills Grid - Responsive */}
       <div
         className={cn(
           "w-full",
@@ -61,12 +82,11 @@ export default function SkillsSection() {
           "flex-wrap content-start"
         )}
       >
-        {skills.map((skill) => (
-          <SkillCard key={skill.name} {...skill} />
+        {skills.map((skill, index) => (
+          <SkillCard key={skill.name} {...skill} index={index} />
         ))}
       </div>
 
-      {/* Resume Button */}
       <SectionMainButton href="/resume.pdf" download="resume.pdf">
         Download Resume
       </SectionMainButton>


### PR DESCRIPTION
Redesigns the Skills and About sections to match the dark refined aesthetic.

Closes #19

Generated with [Claude Code](https://claude.ai/code)