### PR TITLE
feat(#128): admin reply notification email end-to-end

### DIFF
--- a/src/app/actions/admin/__tests__/createAdminReply.test.ts
+++ b/src/app/actions/admin/__tests__/createAdminReply.test.ts
@@ -1,13 +1,42 @@
 import { vi, describe, it, expect, beforeEach } from "vitest";
 
-const { mockVerifyAdminSession, mockCreateAdminReply } = vi.hoisted(() => ({
+const {
+  mockVerifyAdminSession,
+  mockCreateAdminReply,
+  mockGetRootSubmissionOwner,
+  mockSendReplyNotification,
+  mockRegisterMagicLinkCapture,
+  mockSignInMagicLink,
+} = vi.hoisted(() => ({
   mockVerifyAdminSession: vi.fn(),
   mockCreateAdminReply: vi.fn(),
+  mockGetRootSubmissionOwner: vi.fn(),
+  mockSendReplyNotification: vi.fn(),
+  mockRegisterMagicLinkCapture: vi.fn(),
+  mockSignInMagicLink: vi.fn(),
 }));
 
 vi.mock("@/lib/dal/admin", () => ({
   verifyAdminSession: mockVerifyAdminSession,
   createAdminReply: mockCreateAdminReply,
+  getRootSubmissionOwner: mockGetRootSubmissionOwner,
+}));
+
+vi.mock("@/lib/contact/sendNotifications", () => ({
+  sendReplyNotification: mockSendReplyNotification,
+}));
+
+vi.mock("next/headers", () => ({
+  headers: vi.fn().mockResolvedValue({}),
+}));
+
+vi.mock("@/lib/auth/auth", () => ({
+  registerMagicLinkCapture: mockRegisterMagicLinkCapture,
+  auth: {
+    api: {
+      signInMagicLink: mockSignInMagicLink,
+    },
+  },
 }));
 
 import { createAdminReplyAction } from "../createAdminReply";
@@ -79,5 +108,37 @@ describe("createAdminReplyAction", () => {
     const result = await createAdminReplyAction("root-1", "Valid reply");
 
     expect(result).toEqual({ success: false, error: expect.any(String) });
+  });
+
+  it("sends a notification to the thread owner after a successful reply", async () => {
+    mockGetRootSubmissionOwner.mockResolvedValue({ email: "alice@example.com", name: "Alice" });
+    mockRegisterMagicLinkCapture.mockReturnValue(Promise.resolve("https://example.com/magic"));
+    mockSignInMagicLink.mockResolvedValue(undefined);
+
+    await createAdminReplyAction("root-1", "Great question!");
+
+    expect(mockSendReplyNotification).toHaveBeenCalledWith(
+      expect.objectContaining({ to: "alice@example.com", senderName: "Admin" })
+    );
+  });
+
+  it("skips notification without error when getRootSubmissionOwner returns null", async () => {
+    mockGetRootSubmissionOwner.mockResolvedValue(null);
+
+    const result = await createAdminReplyAction("root-1", "Great question!");
+
+    expect(mockSendReplyNotification).not.toHaveBeenCalled();
+    expect(result).toEqual({ success: true, reply: replyRecord });
+  });
+
+  it("still returns success when the notification fails", async () => {
+    mockGetRootSubmissionOwner.mockResolvedValue({ email: "alice@example.com", name: "Alice" });
+    mockRegisterMagicLinkCapture.mockReturnValue(Promise.resolve("https://example.com/magic"));
+    mockSignInMagicLink.mockResolvedValue(undefined);
+    mockSendReplyNotification.mockRejectedValue(new Error("Email down"));
+
+    const result = await createAdminReplyAction("root-1", "Great question!");
+
+    expect(result).toEqual({ success: true, reply: replyRecord });
   });
 });

--- a/src/app/actions/admin/createAdminReply.ts
+++ b/src/app/actions/admin/createAdminReply.ts
@@ -1,8 +1,11 @@
 "use server";
 
 import { z } from "zod";
-import { verifyAdminSession, createAdminReply } from "@/lib/dal/admin";
+import { headers } from "next/headers";
+import { verifyAdminSession, createAdminReply, getRootSubmissionOwner } from "@/lib/dal/admin";
 import type { AdminSubmissionRecord } from "@/lib/dal/admin";
+import { auth, registerMagicLinkCapture } from "@/lib/auth/auth";
+import { sendReplyNotification } from "@/lib/contact/sendNotifications";
 
 const replySchema = z.object({
   body: z.string().trim().min(1, "Reply cannot be empty").max(5000, "Reply is too long"),
@@ -25,6 +28,18 @@ export async function createAdminReplyAction(
 
   try {
     const reply = await createAdminReply(rootId, parsed.data.body, adminSession);
+
+    const owner = await getRootSubmissionOwner(rootId);
+    if (owner) {
+      const h = await headers();
+      const urlCapture = registerMagicLinkCapture(owner.email);
+      await auth.api.signInMagicLink({ body: { email: owner.email, callbackURL: "/portal" }, headers: h });
+      const magicLinkUrl = await urlCapture;
+      sendReplyNotification({ to: owner.email, senderName: adminSession.name, replyBody: parsed.data.body, magicLinkUrl }).catch(
+        (err) => console.error("Failed to send reply notification:", err)
+      );
+    }
+
     return { success: true, reply };
   } catch {
     return { success: false, error: "Failed to send reply." };

--- a/src/components/__tests__/reply-notification-email.test.tsx
+++ b/src/components/__tests__/reply-notification-email.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { ReplyNotificationEmail } from "../reply-notification-email";
+
+describe("ReplyNotificationEmail", () => {
+  it("renders the sender name and reply body", () => {
+    render(<ReplyNotificationEmail senderName="Brady" replyBody="Thanks for reaching out!" />);
+
+    expect(screen.getByRole("heading", { name: /Brady/ })).toBeInTheDocument();
+    expect(screen.getByText("Thanks for reaching out!")).toBeInTheDocument();
+  });
+
+  it("renders a sign-in button linking to the magic link URL when provided", () => {
+    render(
+      <ReplyNotificationEmail
+        senderName="Brady"
+        replyBody="Here is my reply."
+        magicLinkUrl="https://example.com/magic"
+      />
+    );
+
+    const link = screen.getByRole("link", { name: /sign in/i });
+    expect(link).toHaveAttribute("href", "https://example.com/magic");
+  });
+
+  it("does not render a sign-in button when magicLinkUrl is absent", () => {
+    render(<ReplyNotificationEmail senderName="Brady" replyBody="No magic link here." />);
+
+    expect(screen.queryByRole("link", { name: /sign in/i })).toBeNull();
+  });
+});

--- a/src/components/reply-notification-email.tsx
+++ b/src/components/reply-notification-email.tsx
@@ -1,0 +1,54 @@
+import * as React from "react";
+
+interface ReplyNotificationEmailProps {
+  senderName: string;
+  replyBody: string;
+  magicLinkUrl?: string;
+}
+
+export const ReplyNotificationEmail: React.FC<Readonly<ReplyNotificationEmailProps>> = ({
+  senderName,
+  replyBody,
+  magicLinkUrl,
+}) => (
+  <div style={{ fontFamily: "Arial, sans-serif", padding: "20px", color: "#333" }}>
+    <h1 style={{ color: "#2563eb" }}>New Reply from {senderName}</h1>
+
+    <div style={{ margin: "20px 0", lineHeight: "1.5" }}>
+      <p>{replyBody}</p>
+
+      {magicLinkUrl && (
+        <div
+          style={{
+            margin: "24px 0",
+            padding: "16px",
+            background: "#f0f4ff",
+            borderRadius: "8px",
+            border: "1px solid #c7d7ff",
+          }}
+        >
+          <a
+            href={magicLinkUrl}
+            style={{
+              display: "inline-block",
+              padding: "10px 20px",
+              background: "#2563eb",
+              color: "#fff",
+              borderRadius: "6px",
+              textDecoration: "none",
+              fontWeight: "bold",
+            }}
+          >
+            Sign In to Client Portal
+          </a>
+        </div>
+      )}
+    </div>
+
+    <div style={{ marginTop: "30px", borderTop: "1px solid #eee", paddingTop: "20px" }}>
+      <p style={{ fontSize: "14px", color: "#666" }}>Best Regards,</p>
+      <p style={{ fontSize: "16px", fontWeight: "bold", color: "#2563eb" }}>Brady Bovero</p>
+      <p style={{ fontSize: "14px", color: "#666" }}>Freelance Web Developer</p>
+    </div>
+  </div>
+);

--- a/src/lib/contact/__tests__/sendReplyNotification.test.ts
+++ b/src/lib/contact/__tests__/sendReplyNotification.test.ts
@@ -1,0 +1,59 @@
+import { vi, describe, it, expect, beforeEach } from "vitest";
+
+const { mockSend } = vi.hoisted(() => ({
+  mockSend: vi.fn(),
+}));
+
+vi.mock("resend", () => ({
+  Resend: vi.fn().mockImplementation(() => ({
+    emails: { send: mockSend },
+  })),
+}));
+
+vi.mock("@/components/reply-notification-email", () => ({
+  ReplyNotificationEmail: vi.fn().mockReturnValue(null),
+}));
+
+import { sendReplyNotification } from "../sendNotifications";
+
+describe("sendReplyNotification", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSend.mockResolvedValue({ id: "email-123" });
+    process.env.NOTIFICATION_EMAIL = "owner@example.com";
+  });
+
+  it("calls Resend with correct to, senderName and replyBody", async () => {
+    await sendReplyNotification({ to: "alice@example.com", senderName: "Admin", replyBody: "Hello there" });
+
+    expect(mockSend).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "alice@example.com",
+        subject: expect.stringContaining("Admin"),
+      })
+    );
+  });
+
+  it("does not throw when Resend fails", async () => {
+    mockSend.mockRejectedValue(new Error("Resend down"));
+
+    await expect(
+      sendReplyNotification({ to: "alice@example.com", senderName: "Admin", replyBody: "Hello" })
+    ).resolves.toBeUndefined();
+  });
+
+  it("passes magicLinkUrl to the email template when provided", async () => {
+    const { ReplyNotificationEmail } = await import("@/components/reply-notification-email");
+
+    await sendReplyNotification({
+      to: "alice@example.com",
+      senderName: "Admin",
+      replyBody: "Check this",
+      magicLinkUrl: "https://example.com/magic",
+    });
+
+    expect(ReplyNotificationEmail).toHaveBeenCalledWith(
+      expect.objectContaining({ magicLinkUrl: "https://example.com/magic" })
+    );
+  });
+});

--- a/src/lib/contact/sendNotifications.ts
+++ b/src/lib/contact/sendNotifications.ts
@@ -2,6 +2,7 @@ import { Resend } from "resend";
 import { EmailTemplate } from "@/components/email-template";
 import { CustomerConfirmationEmail } from "@/components/customer-confirmation-email";
 import { MagicLinkEmail } from "@/components/magic-link-email";
+import { ReplyNotificationEmail } from "@/components/reply-notification-email";
 
 const resend = new Resend(process.env.RESEND_API_KEY);
 
@@ -23,6 +24,28 @@ export async function sendMagicLinkEmail(email: string, magicLinkUrl: string): P
     });
   } catch (emailError) {
     console.error("Failed to send magic link email:", emailError);
+  }
+}
+
+export interface ReplyNotificationData {
+  to: string;
+  senderName: string;
+  replyBody: string;
+  magicLinkUrl?: string;
+}
+
+export async function sendReplyNotification(data: ReplyNotificationData): Promise<void> {
+  const from = process.env.NOTIFICATION_EMAIL!;
+  const { to, senderName, replyBody, magicLinkUrl } = data;
+  try {
+    await resend.emails.send({
+      from: `Brady Bovero <${from}>`,
+      to,
+      subject: `New reply from ${senderName}`,
+      react: ReplyNotificationEmail({ senderName, replyBody, magicLinkUrl }),
+    });
+  } catch (emailError) {
+    console.error("Failed to send reply notification:", emailError);
   }
 }
 

--- a/src/lib/dal/__tests__/admin.test.ts
+++ b/src/lib/dal/__tests__/admin.test.ts
@@ -58,7 +58,7 @@ vi.mock("@/lib/models/ProspectiveCustomer", () => ({
 import { headers } from "next/headers";
 import { redirect } from "next/navigation";
 import { auth } from "@/lib/auth/auth";
-import { verifyAdminSession, getInbox, getArchived, archiveSubmission, adminDeleteSubmission, getThread, createAdminReply } from "@/lib/dal/admin";
+import { verifyAdminSession, getInbox, getArchived, archiveSubmission, adminDeleteSubmission, getThread, createAdminReply, getRootSubmissionOwner } from "@/lib/dal/admin";
 
 const mockHeaders = headers as ReturnType<typeof vi.fn>;
 const mockGetSession = auth.api.getSession as ReturnType<typeof vi.fn>;
@@ -520,5 +520,39 @@ describe("createAdminReply", () => {
     const result = await createAdminReply("root-1", "Admin reply body", adminSession);
 
     expect(result.sender).toEqual({ name: "Admin", email: "admin@example.com" });
+  });
+});
+
+describe("getRootSubmissionOwner", () => {
+  const VALID_USER_ID = "aaaaaaaaaaaaaaaaaaaaaaaa";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns email and name when root submission and user both exist", async () => {
+    mockFindById.mockResolvedValue({ _id: { toString: () => "root-1" }, userId: VALID_USER_ID });
+    mockFindOne.mockResolvedValue({ email: "alice@example.com", name: "Alice" });
+
+    const result = await getRootSubmissionOwner("root-1");
+
+    expect(result).toEqual({ email: "alice@example.com", name: "Alice" });
+  });
+
+  it("returns null when the root submission does not exist", async () => {
+    mockFindById.mockResolvedValue(null);
+
+    const result = await getRootSubmissionOwner("nonexistent");
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null when the user document does not exist", async () => {
+    mockFindById.mockResolvedValue({ _id: { toString: () => "root-1" }, userId: VALID_USER_ID });
+    mockFindOne.mockResolvedValue(null);
+
+    const result = await getRootSubmissionOwner("root-1");
+
+    expect(result).toBeNull();
   });
 });

--- a/src/lib/dal/admin.ts
+++ b/src/lib/dal/admin.ts
@@ -147,6 +147,17 @@ export async function createAdminReply(
   };
 }
 
+export async function getRootSubmissionOwner(rootId: string): Promise<{ email: string; name: string } | null> {
+  await connectDB();
+  const submission = await ProspectiveCustomer.findById(rootId);
+  if (!submission) return null;
+
+  const userDoc = await db.collection("user").findOne({ _id: new ObjectId(submission.userId) });
+  if (!userDoc) return null;
+
+  return { email: userDoc.email as string, name: userDoc.name as string };
+}
+
 export async function getThread(rootId: string): Promise<AdminThread | null> {
   await connectDB();
 


### PR DESCRIPTION
## Summary

- Adds `getRootSubmissionOwner(rootId)` DAL helper — queries root submission then BetterAuth user collection, returns `{ email, name } | null`
- Adds `ReplyNotificationEmail` component — renders senderName, replyBody, and an optional Magic Link sign-in button
- Adds `sendReplyNotification` fire-and-forget helper in the notifications module
- Wires notification into `createAdminReplyAction`: Magic Link capture → sign-in → fire-and-forget send; skipped silently when owner is null; failures never return `{ success: false }`

Closes #128

## Test plan

- [x] `getRootSubmissionOwner`: found / submission missing / user missing
- [x] `ReplyNotificationEmail`: renders sender + body, renders sign-in button with magic link, no button without magic link
- [x] `sendReplyNotification`: sends with correct args, does not throw on Resend failure, passes magicLinkUrl to template
- [x] `createAdminReplyAction`: notification sent after success, skipped when owner null, action succeeds when notification fails