### PR TITLE
feat(#129): user reply notification email end-to-end

### DIFF
--- a/handoff-reply-notifications-impl.md
+++ b/handoff-reply-notifications-impl.md
@@ -1,0 +1,122 @@
+# Handoff: Implement Reply Notification Emails — Issues #128 and #129
+
+## Next session goal
+
+Implement issues #128 and #129 using TDD on a short-lived `ai/issue-<N>` branch off `feature/conversation-threading_1`, then open PRs back into that feature branch.
+
+Use the workflow:
+1. `/git-ai-issue-start` — branch setup
+2. `/tdd` — Red → Green → Refactor for each slice
+3. Commit with `RALPH:` prefix, close issue with `gh issue close`
+
+---
+
+## Context
+
+### PRD
+GitHub Issue #127 — "PRD: Reply Notification Emails"
+https://github.com/ozbo1973-dev/ozbo1973_portfolio/issues/127
+
+### Implementation issues
+
+| Issue | Title | Blocked by |
+|-------|-------|------------|
+| [#128](https://github.com/ozbo1973-dev/ozbo1973_portfolio/issues/128) | feat: Admin Reply notification email (end-to-end) | None — start here |
+| [#129](https://github.com/ozbo1973-dev/ozbo1973_portfolio/issues/129) | feat: User Reply notification email (end-to-end) | #128 |
+
+### Branch context
+- Feature branch: `feature/conversation-threading_1`
+- Work branches to create: `ai/issue-128`, `ai/issue-129`
+- PRs target `feature/conversation-threading_1`, never `main`
+
+---
+
+## What was decided (from PRD #127)
+
+| # | Decision |
+|---|----------|
+| 1 | Every Admin Reply notification includes a fresh Magic Link — even if the User has an active session |
+| 2 | Email logic lives in server actions, not DAL functions |
+| 3 | New DAL helper `getRootSubmissionOwner(rootId)` in `src/lib/dal/admin.ts` — returns `{ email: string; name: string } \| null` |
+| 4 | Admin notification email uses `process.env.NOTIFICATION_EMAIL` as sender — no DB lookup for recipient on admin side |
+| 5 | One shared `ReplyNotificationEmail` template — `senderName`, `replyBody`, optional `magicLinkUrl`; sign-in button if magic link present, plain note if not |
+| 6 | Magic Link `callbackURL` is `/portal` |
+| 7 | Notification failure is fire-and-forget — `console.error` on failure, never surfaces to sender |
+
+---
+
+## Issue #128 — Admin Reply notification (full vertical slice)
+
+**New files:**
+- `src/lib/dal/admin.ts` — add `getRootSubmissionOwner(rootId: string)`
+- `src/components/reply-notification-email.tsx` — new template (Magic Link path only for this issue)
+- `src/lib/contact/sendNotifications.ts` — add `sendReplyNotification({ to, senderName, replyBody, magicLinkUrl? })`
+- `src/app/actions/admin/createAdminReply.ts` — wire notification after successful reply
+
+**Admin Reply wiring sequence:**
+1. `getRootSubmissionOwner(rootId)` — skip if null
+2. `registerMagicLinkCapture(owner.email)` + `auth.api.signInMagicLink({ body: { email: owner.email, callbackURL: "/portal" }, headers: h })`
+3. `await urlCapture` to get Magic Link URL
+4. Fire-and-forget `sendReplyNotification({ to: owner.email, senderName: adminSession.name, replyBody, magicLinkUrl })`
+
+**Magic Link capture pattern** — already established in `src/lib/auth/actions/signIn.ts`. Replicate exactly.
+
+**Style reference for template** — `src/components/magic-link-email.tsx`
+
+**Tests to write (prior art: `src/lib/dal/__tests__/admin.test.ts`, `src/app/actions/admin/__tests__/createAdminReply.test.ts`):**
+- `getRootSubmissionOwner`: found / submission missing / user missing
+- `sendReplyNotification`: success / Resend failure / with magic link present
+- `createAdminReplyAction`: notification sent / skipped when owner null / action still returns success when notification fails
+
+---
+
+## Issue #129 — User Reply notification (full vertical slice)
+
+**Changes (after #128 is merged):**
+- `src/components/reply-notification-email.tsx` — add no-magic-link render path (Admin Console note)
+- `src/app/actions/createUserReply.ts` — wire fire-and-forget `sendReplyNotification` after successful reply
+
+**User Reply wiring:**
+- `sendReplyNotification({ to: process.env.NOTIFICATION_EMAIL!, senderName: session.name, replyBody: parsed.data.body })`
+- No Magic Link
+- Failure must never cause `{ success: false }`
+
+**Tests (prior art: `src/app/actions/__tests__/createUserReply.test.ts`):**
+- `ReplyNotificationEmail` no-magic-link render path
+- `createUserReplyAction`: notification sent / action succeeds when notification fails
+
+---
+
+## Key files
+
+| File | Role |
+|------|------|
+| `src/lib/dal/admin.ts` | Add `getRootSubmissionOwner` |
+| `src/app/actions/admin/createAdminReply.ts` | Wire Admin notification |
+| `src/app/actions/createUserReply.ts` | Wire User notification |
+| `src/lib/contact/sendNotifications.ts` | Add `sendReplyNotification` |
+| `src/components/reply-notification-email.tsx` | New shared email template |
+| `src/lib/auth/auth.ts` | `registerMagicLinkCapture` — no changes needed |
+| `src/components/magic-link-email.tsx` | Style reference |
+| `src/lib/dal/__tests__/admin.test.ts` | Prior art for DAL tests |
+| `src/app/actions/admin/__tests__/createAdminReply.test.ts` | Prior art for action tests |
+
+---
+
+## Domain language
+
+- **Reply** — Submission with non-null `parentId`
+- **Thread** — Root Submission + all Replies
+- **User** — authenticated identity (not "customer")
+- **Admin** — User with `role: "admin"`
+- **Magic Link** — single-use auth URL (not "login link")
+- **Portal** — `/portal`
+- **Admin Console** — `/admin`
+
+---
+
+## Suggested skills for next session
+
+1. `git-ai-issue-start` — set up `ai/issue-128` off `feature/conversation-threading_1`
+2. `/tdd` — Red → Green → Refactor for each slice
+3. After #128 PR merged: repeat for #129

--- a/handoff-reply-notifications.md
+++ b/handoff-reply-notifications.md
@@ -1,0 +1,115 @@
+# Handoff: Reply Notification Emails — PRD + GitHub Issues
+
+## Next session goal
+
+Convert the finalized design (below) into a PRD and GitHub Issues ready for implementation. Use `/to-prd` then `/to-issues`.
+
+---
+
+## What was decided
+
+A grilling session (`/grill-with-docs`) produced a fully-resolved design for sending notification emails when Admin or User posts a Reply in a Thread.
+
+### Feature summary
+
+When the **Admin** posts a Reply, the **User** receives a notification email containing:
+- Admin's name
+- Reply body
+- A Magic Link (single-use, 24hr, `callbackURL: "/portal"`) so the User can sign in and view the Thread
+
+When a **User** posts a Reply, the **Admin** receives a notification email containing:
+- User's name
+- Reply body
+- A note to check the Admin Console (no Magic Link — Admin authenticates separately)
+
+---
+
+## Finalized design decisions (all grilling questions resolved)
+
+| # | Decision |
+|---|----------|
+| 1 | Every Admin Reply notification includes a fresh Magic Link — even if the User has an active Session |
+| 2 | Email logic lives in **server actions**, not DAL functions |
+| 3 | New DAL helper `getRootSubmissionOwner(rootId)` added to `src/lib/dal/admin.ts` — returns `{ email: string; name: string } | null` using shared `db` + `ObjectId` (already imported) |
+| 4 | Admin notification email uses `process.env.NOTIFICATION_EMAIL` — no DB lookup needed |
+| 5 | One shared `ReplyNotificationEmail` template — accepts `senderName`, `replyBody`, optional `magicLinkUrl`; renders sign-in button if magic link present, plain note if not |
+| 6 | Magic Link `callbackURL` is `/portal` (not a deep link to the Thread) |
+| 7 | Notification failure is fire-and-forget — `console.error` on failure, never surfaces to sender |
+| 8 | `getRootSubmissionOwner` shape: `Promise<{ email: string; name: string } | null>` |
+
+---
+
+## Implementation scope (3 steps)
+
+### Step 1 — DAL helper
+**File:** `src/lib/dal/admin.ts`
+- Add `getRootSubmissionOwner(rootId: string): Promise<{ email: string; name: string } | null>`
+- Find Root Submission by `rootId`, then query `db.collection("user").findOne({ _id: new ObjectId(submission.userId) })`
+- Return `null` if submission or user not found
+
+### Step 2 — Email template
+**File:** `src/components/reply-notification-email.tsx` (new)
+- Props: `senderName: string`, `replyBody: string`, `magicLinkUrl?: string`
+- If `magicLinkUrl` present: render sign-in button (match style of `magic-link-email.tsx`)
+- If not: render "Log in to the Admin Console to respond" note
+
+### Step 3a — Wire into `createAdminReplyAction`
+**File:** `src/app/actions/admin/createAdminReply.ts`
+After `createAdminReply(...)` succeeds:
+1. Call `getRootSubmissionOwner(rootId)` — if null, skip notification
+2. `registerMagicLinkCapture(owner.email)` + `auth.api.signInMagicLink({ body: { email: owner.email, callbackURL: "/portal" }, headers: h })`
+3. `await urlCapture` to get Magic Link URL
+4. Fire-and-forget: `sendReplyNotification({ to: owner.email, senderName: adminSession.name, replyBody, magicLinkUrl })`
+
+### Step 3b — Wire into `createUserReplyAction`
+**File:** `src/app/actions/createUserReply.ts`
+After `createUserReply(...)` succeeds:
+1. Fire-and-forget: `sendReplyNotification({ to: process.env.NOTIFICATION_EMAIL!, senderName: session.name, replyBody: parsed.data.body })`
+
+### Step 3c — Add `sendReplyNotification` to `sendNotifications.ts`
+**File:** `src/lib/contact/sendNotifications.ts`
+- New export: `sendReplyNotification({ to, senderName, replyBody, magicLinkUrl? })`
+- Fire-and-forget pattern matching `sendNotifications`
+
+---
+
+## Key files
+
+| File | Role |
+|------|------|
+| `src/lib/dal/admin.ts` | Add `getRootSubmissionOwner` |
+| `src/lib/dal/prospects.ts` | `createUserReply` — no changes needed |
+| `src/app/actions/admin/createAdminReply.ts` | Wire notification (Step 3a) |
+| `src/app/actions/createUserReply.ts` | Wire notification (Step 3b) |
+| `src/lib/contact/sendNotifications.ts` | Add `sendReplyNotification` (Step 3c) |
+| `src/components/reply-notification-email.tsx` | New email template (Step 2) |
+| `src/lib/auth/auth.ts` | `registerMagicLinkCapture` — no changes needed |
+| `src/components/magic-link-email.tsx` | Style reference for new template |
+| `CONTEXT.md` | Domain glossary — use canonical terms |
+
+---
+
+## Domain language (from CONTEXT.md)
+
+Use these terms precisely in the PRD and issues:
+- **Reply** — a Submission with non-null `parentId`
+- **Thread** — Root Submission + all Replies
+- **User** — authenticated identity (not "customer" or "client")
+- **Admin** — User with `role: "admin"`
+- **Magic Link** — single-use auth URL (not "login link")
+- **Portal** — `/portal` (not "dashboard")
+- **Admin Console** — `/admin` (not "admin panel")
+
+---
+
+## Suggested skills for next session
+
+1. `/to-prd` — generate PRD from this handoff context
+2. `/to-issues` — break PRD into independently-grabbable GitHub Issues
+
+---
+
+## Branch context
+
+Current branch: `feature/conversation-threading_1`
+Recent commits: see `git log` — threading feature is in progress; this notification work extends it.

--- a/src/app/actions/__tests__/createUserReply.test.ts
+++ b/src/app/actions/__tests__/createUserReply.test.ts
@@ -1,13 +1,18 @@
 import { vi, describe, it, expect, beforeEach } from "vitest";
 
-const { mockVerifySession, mockCreateUserReply } = vi.hoisted(() => ({
+const { mockVerifySession, mockCreateUserReply, mockSendReplyNotification } = vi.hoisted(() => ({
   mockVerifySession: vi.fn(),
   mockCreateUserReply: vi.fn(),
+  mockSendReplyNotification: vi.fn(),
 }));
 
 vi.mock("@/lib/dal/prospects", () => ({
   verifySession: mockVerifySession,
   createUserReply: mockCreateUserReply,
+}));
+
+vi.mock("@/lib/contact/sendNotifications", () => ({
+  sendReplyNotification: mockSendReplyNotification,
 }));
 
 import { createUserReplyAction } from "../createUserReply";
@@ -24,8 +29,10 @@ const replyRecord = {
 describe("createUserReplyAction", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    process.env.NOTIFICATION_EMAIL = "admin@example.com";
     mockVerifySession.mockResolvedValue(userSession);
     mockCreateUserReply.mockResolvedValue(replyRecord);
+    mockSendReplyNotification.mockResolvedValue(undefined);
   });
 
   it("returns success with reply when input is valid", async () => {
@@ -75,5 +82,25 @@ describe("createUserReplyAction", () => {
     const result = await createUserReplyAction("root-1", "Valid reply");
 
     expect(result).toEqual({ success: false, error: expect.any(String) });
+  });
+
+  it("fires sendReplyNotification after a successful reply", async () => {
+    mockSendReplyNotification.mockResolvedValue(undefined);
+
+    await createUserReplyAction("root-1", "Thanks for the update!");
+
+    expect(mockSendReplyNotification).toHaveBeenCalledWith({
+      to: "admin@example.com",
+      senderName: userSession.name,
+      replyBody: "Thanks for the update!",
+    });
+  });
+
+  it("still returns success when sendReplyNotification throws", async () => {
+    mockSendReplyNotification.mockRejectedValue(new Error("Resend is down"));
+
+    const result = await createUserReplyAction("root-1", "Thanks for the update!");
+
+    expect(result).toEqual({ success: true, reply: replyRecord });
   });
 });

--- a/src/app/actions/createUserReply.ts
+++ b/src/app/actions/createUserReply.ts
@@ -3,6 +3,7 @@
 import { z } from "zod";
 import { verifySession, createUserReply } from "@/lib/dal/prospects";
 import type { UserThreadRecord } from "@/lib/dal/prospects";
+import { sendReplyNotification } from "@/lib/contact/sendNotifications";
 
 const replySchema = z.object({
   body: z.string().trim().min(1, "Reply cannot be empty").max(5000, "Reply is too long"),
@@ -25,6 +26,11 @@ export async function createUserReplyAction(
 
   try {
     const reply = await createUserReply(rootId, session.userId, parsed.data.body);
+    sendReplyNotification({
+      to: process.env.NOTIFICATION_EMAIL!,
+      senderName: session.name,
+      replyBody: parsed.data.body,
+    }).catch(() => {});
     return { success: true, reply };
   } catch {
     return { success: false, error: "Failed to send reply." };

--- a/src/components/__tests__/reply-notification-email.test.tsx
+++ b/src/components/__tests__/reply-notification-email.test.tsx
@@ -28,4 +28,10 @@ describe("ReplyNotificationEmail", () => {
 
     expect(screen.queryByRole("link", { name: /sign in/i })).toBeNull();
   });
+
+  it("renders an Admin Console note when magicLinkUrl is absent", () => {
+    render(<ReplyNotificationEmail senderName="Brady" replyBody="No magic link here." />);
+
+    expect(screen.getByText(/admin console/i)).toBeInTheDocument();
+  });
 });

--- a/src/components/reply-notification-email.tsx
+++ b/src/components/reply-notification-email.tsx
@@ -17,6 +17,12 @@ export const ReplyNotificationEmail: React.FC<Readonly<ReplyNotificationEmailPro
     <div style={{ margin: "20px 0", lineHeight: "1.5" }}>
       <p>{replyBody}</p>
 
+      {!magicLinkUrl && (
+        <p style={{ marginTop: "16px", color: "#555" }}>
+          Check the Admin Console to view and respond to this reply.
+        </p>
+      )}
+
       {magicLinkUrl && (
         <div
           style={{


### PR DESCRIPTION
## Summary

- `ReplyNotificationEmail` now renders an "Admin Console" note when `magicLinkUrl` is absent, replacing the sign-in button path
- `createUserReplyAction` fires `sendReplyNotification` fire-and-forget after a successful reply — `to: NOTIFICATION_EMAIL`, no magic link
- A failed notification never causes the action to return `{ success: false }`

Closes #129

## Test plan

- [x] `ReplyNotificationEmail` renders Admin Console note when `magicLinkUrl` absent (positive assertion)
- [x] `ReplyNotificationEmail` does not render sign-in button when `magicLinkUrl` absent
- [x] `createUserReplyAction` calls `sendReplyNotification` with correct args after success
- [x] `createUserReplyAction` returns `{ success: true }` even when `sendReplyNotification` throws
- [x] All 13 tests (4 email + 9 action) pass